### PR TITLE
Encode login token headers as JSON

### DIFF
--- a/api/route/user.go
+++ b/api/route/user.go
@@ -3,6 +3,7 @@ package route
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"errors"
 	"net/http"
 	"strconv"
@@ -11,6 +12,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
+	"github.com/wsuzume/prism/api/token"
 	"golang.org/x/crypto/bcrypt"
 )
 
@@ -250,9 +252,33 @@ func (d *Database) LoginUser(c *gin.Context) {
 		return
 	}
 
-	c.Header("PRISM-SECRET", "secret-token")
-	c.Header("PRISM-ACCESS", "access-token")
-	c.Header("PRISM-PUBLIC", "public-token")
+	secretToken, err := json.Marshal(token.SecretToken{
+		SecretPayload: "secret-token",
+	})
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to encode secret token"})
+		return
+	}
+
+	accessToken, err := json.Marshal(token.AccessToken{
+		AccessPayload: "access-token",
+	})
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to encode access token"})
+		return
+	}
+
+	publicToken, err := json.Marshal(token.PublicToken{
+		PublicPayload: "public-token",
+	})
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to encode public token"})
+		return
+	}
+
+	c.Header("PRISM-SECRET", string(secretToken))
+	c.Header("PRISM-ACCESS", string(accessToken))
+	c.Header("PRISM-PUBLIC", string(publicToken))
 
 	c.JSON(http.StatusOK, u)
 }

--- a/api/route/user.go
+++ b/api/route/user.go
@@ -253,7 +253,7 @@ func (d *Database) LoginUser(c *gin.Context) {
 	}
 
 	secretToken, err := json.Marshal(token.SecretToken{
-		SecretPayload: "secret-token",
+		UserID: u.ID,
 	})
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to encode secret token"})
@@ -261,7 +261,7 @@ func (d *Database) LoginUser(c *gin.Context) {
 	}
 
 	accessToken, err := json.Marshal(token.AccessToken{
-		AccessPayload: "access-token",
+		UserID: u.ID,
 	})
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to encode access token"})
@@ -269,7 +269,7 @@ func (d *Database) LoginUser(c *gin.Context) {
 	}
 
 	publicToken, err := json.Marshal(token.PublicToken{
-		PublicPayload: "public-token",
+		Email: u.Email,
 	})
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to encode public token"})

--- a/api/token/token.go
+++ b/api/token/token.go
@@ -2,17 +2,15 @@ package token
 
 // SecretToken represents the payload returned to clients via the PRISM-SECRET header.
 type SecretToken struct {
-	SecretPayload string `json:"secretPayload"`
-	JTI           string `json:"jti,omitempty"`
+	UserID string `json:"user_id"`
 }
 
 // AccessToken represents the payload returned to clients via the PRISM-ACCESS header.
 type AccessToken struct {
-	AccessPayload string `json:"accessPayload"`
-	JTI           string `json:"jti,omitempty"`
+	UserID string `json:"user_id"`
 }
 
 // PublicToken represents the payload returned to clients via the PRISM-PUBLIC header.
 type PublicToken struct {
-	PublicPayload string `json:"publicPayload"`
+	Email string `json:"email"`
 }

--- a/api/token/token.go
+++ b/api/token/token.go
@@ -1,0 +1,18 @@
+package token
+
+// SecretToken represents the payload returned to clients via the PRISM-SECRET header.
+type SecretToken struct {
+	SecretPayload string `json:"secretPayload"`
+	JTI           string `json:"jti,omitempty"`
+}
+
+// AccessToken represents the payload returned to clients via the PRISM-ACCESS header.
+type AccessToken struct {
+	AccessPayload string `json:"accessPayload"`
+	JTI           string `json:"jti,omitempty"`
+}
+
+// PublicToken represents the payload returned to clients via the PRISM-PUBLIC header.
+type PublicToken struct {
+	PublicPayload string `json:"publicPayload"`
+}


### PR DESCRIPTION
## Summary
- add token payload structures for PRISM-SECRET, PRISM-ACCESS, and PRISM-PUBLIC headers
- marshal the new token structures to JSON when issuing headers from the login handler

## Testing
- go test ./... *(fails: command hung while downloading module dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68f0ef0d31b88321b795fd2b9a8232f9