### PR TITLE
Add settings page for viewing stored user information

### DIFF
--- a/pkg/csrf/csrf.go
+++ b/pkg/csrf/csrf.go
@@ -18,6 +18,7 @@ import (
 	"github.com/wsuzume/prism/pkg/cipher"
 	"github.com/wsuzume/prism/pkg/iprange"
 	"github.com/wsuzume/prism/pkg/jwt"
+	"github.com/wsuzume/prism/pkg/mode"
 	"github.com/wsuzume/prism/pkg/msg"
 )
 
@@ -800,13 +801,22 @@ func (p *DoubleSubmitCookieCSRFProtector) ModifyResponse(orig func(*http.Respons
 		accessToken.claims.Usr = encodedAccessPayload
 		accessToken.aad = encodedPublicPayloadBytes
 
-		secretTokenStr, accessTokenStr, err := p.encryptSessionTokens(secretToken, accessToken, encodedPublicPayloadBytes)
+		// secretTokenStr, accessTokenStr, err := p.encryptSessionTokens(secretToken, accessToken, encodedPublicPayloadBytes)
+		secretTokenStr, accessTokenStr, err := p.encryptSessionTokens(secretToken, accessToken, []byte(publicPayload))
 		if err != nil {
 			return err
 		}
 
-		resp.Header.Add("Set-Cookie", p.newSecretCookie(secretTokenStr).String())
-		resp.Header.Add("Set-Cookie", p.newAccessCookie(accessTokenStr).String())
+		secretCookie := p.newSecretCookie(secretTokenStr).String()
+		accessCookie := p.newAccessCookie(accessTokenStr).String()
+
+		resp.Header.Add("Set-Cookie", secretCookie)
+		resp.Header.Add("Set-Cookie", accessCookie)
+
+		if mode.Debug {
+			log.Printf("SecretCookie: %s\n", secretCookie)
+			log.Printf("AccessCookie: %s\n", accessCookie)
+		}
 
 		return nil
 	}

--- a/proxy/internal/server/proxy.go
+++ b/proxy/internal/server/proxy.go
@@ -88,6 +88,9 @@ func RunReverseProxy(cmd *cobra.Command, args []string) {
 
 	// Double-Submit Cookie（暗号化付き）
 	dscp := csrf.DefaultDoubleSubmitCookieCSRFProtector(encrypter)
+	if mode.Debug {
+		dscp.SecureCookie = false
+	}
 	dscp.IdentityCenterAddressPool, err = iprange.ParseRanges(cfg.IdentityCenterAddresses)
 	if err != nil {
 		log.Fatalf("failed to parse identity_center_addresses: %v", err)

--- a/react/src/App.tsx
+++ b/react/src/App.tsx
@@ -5,6 +5,7 @@ import Login from "./pages/Login";
 import NotePage from "./pages/Note";
 import NoteCreate from "./pages/NoteCreate";
 import Signup from "./pages/Signup";
+import Settings from "./pages/Settings";
 import UserPage from "./pages/User";
 
 export default function App() {
@@ -14,6 +15,7 @@ export default function App() {
         <Route path="/" element={<Home />} />
         <Route path="/login" element={<Login />} />
         <Route path="/signup" element={<Signup />} />
+        <Route path="/settings" element={<Settings />} />
         <Route path="/note" element={<NotePage />} />
         <Route path="/note/new" element={<NoteCreate />} />
         <Route path="/user" element={<UserPage />} />

--- a/react/src/components/Sidebar.tsx
+++ b/react/src/components/Sidebar.tsx
@@ -32,6 +32,11 @@ const Sidebar: React.FC = () => {
         <NavItem to="/" label="Home" active={loc.pathname === "/"} />
         <NavItem to="/user" label="Users" active={loc.pathname.startsWith("/user")} />
         <NavItem to="/note" label="Notes" active={loc.pathname.startsWith("/note")} />
+        <NavItem
+          to="/settings"
+          label="Settings"
+          active={loc.pathname.startsWith("/settings")}
+        />
         <NavItem to="/login" label="Login" active={loc.pathname.startsWith("/login")} />
         <NavItem to="/signup" label="Signup" active={loc.pathname.startsWith("/signup")} />
       </nav>

--- a/react/src/pages/Login.tsx
+++ b/react/src/pages/Login.tsx
@@ -47,7 +47,7 @@ const Login: React.FC = () => {
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ email, password }),
         signal: ac.signal,
-        credentials: "same-origin",
+        credentials: "include",
       });
 
       // レスポンス全体を確認

--- a/react/src/pages/Login.tsx
+++ b/react/src/pages/Login.tsx
@@ -1,6 +1,7 @@
 // src/pages/Login.tsx
 import React, { useRef, useState } from "react";
-import { Link, useNavigate } from "react-router-dom";
+// import { Link, useNavigate } from "react-router-dom";
+import { Link } from "react-router-dom";
 import { setCurrentUser } from "../session";
 
 type LoginUser = {
@@ -18,7 +19,7 @@ const Login: React.FC = () => {
   const [msg, setMsg] = useState<string>("");
   const [loading, setLoading] = useState(false);
   const abortRef = useRef<AbortController | null>(null);
-  const navigate = useNavigate(); // 追加
+  // const navigate = useNavigate(); // 追加
 
   const onSubmit: React.FormEventHandler<HTMLFormElement> = async (e) => {
     e.preventDefault();
@@ -47,7 +48,7 @@ const Login: React.FC = () => {
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ email, password }),
         signal: ac.signal,
-        credentials: "include",
+        credentials: "same-origin",
       });
 
       // レスポンス全体を確認
@@ -69,7 +70,7 @@ const Login: React.FC = () => {
         const user: LoginUser = await res.json();
         setCurrentUser(user);
         // リダイレクト（履歴を置き換え）
-        navigate("/", { replace: true });
+        // navigate("/", { replace: true });
         return;
       } else {
         let detail = "";

--- a/react/src/pages/Note.tsx
+++ b/react/src/pages/Note.tsx
@@ -58,7 +58,7 @@ const NotePage: React.FC = () => {
         const res = await fetch(url, {
           signal: ac.signal,
           headers: { Accept: "application/json" },
-          credentials: "include",
+          credentials: "same-origin",
         });
         if (!res.ok) {
           const text = await res.text().catch(() => "");

--- a/react/src/pages/Note.tsx
+++ b/react/src/pages/Note.tsx
@@ -58,6 +58,7 @@ const NotePage: React.FC = () => {
         const res = await fetch(url, {
           signal: ac.signal,
           headers: { Accept: "application/json" },
+          credentials: "include",
         });
         if (!res.ok) {
           const text = await res.text().catch(() => "");

--- a/react/src/pages/NoteCreate.tsx
+++ b/react/src/pages/NoteCreate.tsx
@@ -54,7 +54,7 @@ const NoteCreate: React.FC = () => {
           canonical_name: form.canonical_name.trim(),
           content: form.content.trim(),
         }),
-        credentials: "include",
+        credentials: "same-origin",
       });
       if (!res.ok) {
         const text = await res.text().catch(() => "");

--- a/react/src/pages/NoteCreate.tsx
+++ b/react/src/pages/NoteCreate.tsx
@@ -54,6 +54,7 @@ const NoteCreate: React.FC = () => {
           canonical_name: form.canonical_name.trim(),
           content: form.content.trim(),
         }),
+        credentials: "include",
       });
       if (!res.ok) {
         const text = await res.text().catch(() => "");

--- a/react/src/pages/Settings.tsx
+++ b/react/src/pages/Settings.tsx
@@ -1,0 +1,107 @@
+// src/pages/Settings.tsx
+import React, { useMemo } from "react";
+import Sidebar from "../components/Sidebar";
+import { getCurrentUser } from "../session";
+
+const formatDate = (value: string) =>
+  new Date(value).toLocaleString(undefined, {
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+  });
+
+const Settings: React.FC = () => {
+  const user = getCurrentUser();
+
+  const details = useMemo(() => {
+    if (!user) return null;
+    return [
+      { label: "ID", value: user.id },
+      { label: "Email", value: user.email },
+      {
+        label: "Created",
+        value: user.created_at ? formatDate(user.created_at) : "-",
+      },
+      {
+        label: "Updated",
+        value: user.updated_at ? formatDate(user.updated_at) : "-",
+      },
+    ];
+  }, [user]);
+
+  return (
+    <div
+      className="layout"
+      style={{
+        display: "grid",
+        gridTemplateColumns: "240px 1fr",
+        height: "100vh",
+      }}
+    >
+      <Sidebar />
+      <main style={{ padding: 24, overflow: "auto" }}>
+        <h1 className="title" style={{ marginBottom: 16 }}>
+          Settings
+        </h1>
+
+        <section
+          className="card"
+          style={{
+            maxWidth: 600,
+            border: "1px solid #e5e7eb",
+            borderRadius: 12,
+            padding: 24,
+            background: "#fff",
+            boxShadow: "0 10px 25px -20px rgba(15, 23, 42, 0.45)",
+          }}
+        >
+          <header style={{ marginBottom: 16 }}>
+            <h2 style={{ fontSize: 20, fontWeight: 600, margin: 0 }}>Profile</h2>
+            <p style={{ margin: "6px 0 0", color: "#6b7280" }}>
+              ローカルに保持している現在のユーザー情報を表示します。
+            </p>
+          </header>
+
+          {user ? (
+            <dl
+              style={{
+                display: "grid",
+                gridTemplateColumns: "120px 1fr",
+                rowGap: 12,
+                columnGap: 16,
+                margin: 0,
+              }}
+            >
+              {details!.map(({ label, value }) => (
+                <React.Fragment key={label}>
+                  <dt style={{ fontWeight: 600, color: "#374151" }}>{label}</dt>
+                  <dd
+                    style={{
+                      margin: 0,
+                      fontFamily:
+                        label === "ID"
+                          ? "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace"
+                          : "inherit",
+                      wordBreak: "break-word",
+                    }}
+                  >
+                    {value}
+                  </dd>
+                </React.Fragment>
+              ))}
+            </dl>
+          ) : (
+            <p style={{ margin: 0, color: "#6b7280" }}>
+              現在サインインしているユーザーはありません。
+            </p>
+          )}
+        </section>
+      </main>
+    </div>
+  );
+};
+
+export default Settings;

--- a/react/src/pages/Settings.tsx
+++ b/react/src/pages/Settings.tsx
@@ -29,6 +29,10 @@ const Settings: React.FC = () => {
         label: "Updated",
         value: user.updated_at ? formatDate(user.updated_at) : "-",
       },
+      {
+        label: "Access Token",
+        value: user.accessToken ? user.accessToken : "-",
+      },
     ];
   }, [user]);
 

--- a/react/src/pages/Settings.tsx
+++ b/react/src/pages/Settings.tsx
@@ -33,6 +33,12 @@ const Settings: React.FC = () => {
         label: "Access Token",
         value: user.accessToken ? user.accessToken : "-",
       },
+      {
+        label: "Access Token Payload",
+        value: user.accessTokenPayload
+          ? JSON.stringify(user.accessTokenPayload, null, 2) // 見やすく整形
+          : "-",
+      },
     ];
   }, [user]);
 

--- a/react/src/pages/Signup.tsx
+++ b/react/src/pages/Signup.tsx
@@ -33,6 +33,7 @@ const Signup: React.FC = () => {
         method: "POST",
         headers: { "Content-Type": "application/json", Accept: "application/json" },
         body: JSON.stringify({ email, password }),
+        credentials: "include",
       });
 
       if (!res.ok) {

--- a/react/src/pages/Signup.tsx
+++ b/react/src/pages/Signup.tsx
@@ -33,7 +33,7 @@ const Signup: React.FC = () => {
         method: "POST",
         headers: { "Content-Type": "application/json", Accept: "application/json" },
         body: JSON.stringify({ email, password }),
-        credentials: "include",
+        credentials: "same-origin",
       });
 
       if (!res.ok) {

--- a/react/src/pages/User.tsx
+++ b/react/src/pages/User.tsx
@@ -46,6 +46,7 @@ const UserPage: React.FC = () => {
         const res = await fetch(`/api/user?limit=${limit}&offset=${offset}`, {
           signal: ac.signal,
           headers: { Accept: "application/json" },
+          credentials: "include",
         });
         if (!res.ok) {
           const text = await res.text().catch(() => "");

--- a/react/src/pages/User.tsx
+++ b/react/src/pages/User.tsx
@@ -46,7 +46,7 @@ const UserPage: React.FC = () => {
         const res = await fetch(`/api/user?limit=${limit}&offset=${offset}`, {
           signal: ac.signal,
           headers: { Accept: "application/json" },
-          credentials: "include",
+          credentials: "same-origin",
         });
         if (!res.ok) {
           const text = await res.text().catch(() => "");

--- a/react/src/session.ts
+++ b/react/src/session.ts
@@ -6,48 +6,128 @@ export type StoredCurrentUser = {
   updated_at: string;
 };
 
+type TokenPayload = Record<string, unknown>;
+
 export type CurrentUser = StoredCurrentUser & {
   accessToken: string | null;
+  accessTokenPayload: TokenPayload | null;
 };
 
 const KEY = "app.currentUser";
 const ACCESS_TOKEN_COOKIE = "PRISM-ACCESS-TOKEN";
 
+function log(...args: any[]) {
+  // 必要ならここでビルドタグ/環境変数に応じて無効化可能
+  console.log("[session]", ...args);
+}
+
 function readCookie(name: string): string | null {
-  if (typeof document === "undefined") return null;
+  if (typeof document === "undefined") {
+    log("readCookie: document is undefined (SSR?)");
+    return null;
+  }
 
   const cookieString = document.cookie;
-  if (!cookieString) return null;
+  if (!cookieString) {
+    log("readCookie: document.cookie is empty");
+    return null;
+  }
 
   const cookies = cookieString.split(";");
   for (const cookie of cookies) {
     const [rawName, ...rest] = cookie.split("=");
     if (!rawName) continue;
     if (rawName.trim() !== name) continue;
-    return decodeURIComponent(rest.join("=").trim());
+    const v = decodeURIComponent(rest.join("=").trim());
+    log("readCookie: found", name, "len=", v?.length ?? 0);
+    return v;
   }
 
+  log("readCookie: not found", name);
   return null;
+}
+
+function base64UrlToUtf8(b64url: string): string {
+  // base64url → base64（-/_ → +/、パディング補完）
+  let b64 = b64url.replace(/-/g, "+").replace(/_/g, "/");
+  const pad = b64.length % 4;
+  if (pad === 2) b64 += "==";
+  else if (pad === 3) b64 += "=";
+  else if (pad !== 0) {
+    log("base64UrlToUtf8: invalid length", b64url.length);
+    throw new Error("invalid base64url length");
+  }
+  try {
+    const bin = atob(b64);
+    const bytes = Uint8Array.from(bin, c => c.charCodeAt(0));
+    return new TextDecoder().decode(bytes);
+  } catch (e) {
+    log("base64UrlToUtf8: decode error", e);
+    throw e;
+  }
+}
+
+function parseAccessTokenPayload(token: string | undefined | null): TokenPayload | null {
+  log("parseAccessTokenPayload: start, token present?", Boolean(token));
+  if (!token) return null;
+
+  const i = token.indexOf(".");
+  if (i < 0) {
+    log('parseAccessTokenPayload: missing "." separator');
+    return null; // "XXX.YYY" でない
+  }
+
+  const yyy = token.slice(i + 1); // 後段（YYY）
+  log("parseAccessTokenPayload: payload segment length", yyy.length);
+
+  try {
+    const jsonStr = base64UrlToUtf8(yyy);
+    log("parseAccessTokenPayload: decoded JSON string length", jsonStr.length);
+    const obj = JSON.parse(jsonStr) as TokenPayload;
+    log("parseAccessTokenPayload: JSON.parse ok, keys", Object.keys(obj));
+    return obj;
+  } catch (e) {
+    log("parseAccessTokenPayload: parse failed", e);
+    return null;
+  }
 }
 
 export function setCurrentUser(u: StoredCurrentUser | null) {
   if (!u) {
+    log("setCurrentUser: clearing current user");
     localStorage.removeItem(KEY);
     return;
   }
+  log("setCurrentUser: storing user id", u.id);
   localStorage.setItem(KEY, JSON.stringify(u));
 }
 
 export function getCurrentUser(): CurrentUser | null {
   const s = localStorage.getItem(KEY);
-  if (!s) return null;
+  if (!s) {
+    log("getCurrentUser: no stored user");
+    return null;
+  }
   try {
     const stored = JSON.parse(s) as StoredCurrentUser;
+    log("getCurrentUser: loaded stored user", { id: stored.id, email: stored.email });
+
+    const accessToken = readCookie(ACCESS_TOKEN_COOKIE) || null;
+    log("getCurrentUser: accessToken present?", Boolean(accessToken));
+
+    const accessTokenPayload = parseAccessTokenPayload(accessToken);
+    log(
+      "getCurrentUser: accessTokenPayload",
+      accessTokenPayload ? { keys: Object.keys(accessTokenPayload) } : null
+    );
+
     return {
       ...stored,
-      accessToken: readCookie(ACCESS_TOKEN_COOKIE),
+      accessToken,
+      accessTokenPayload,
     };
-  } catch {
+  } catch (e) {
+    log("getCurrentUser: error parsing stored user", e);
     return null;
   }
 }

--- a/react/src/session.ts
+++ b/react/src/session.ts
@@ -1,14 +1,36 @@
 // src/session.ts
-export type CurrentUser = {
+export type StoredCurrentUser = {
   id: string;
   email: string;
   created_at: string;
   updated_at: string;
 };
 
-const KEY = "app.currentUser";
+export type CurrentUser = StoredCurrentUser & {
+  accessToken: string | null;
+};
 
-export function setCurrentUser(u: CurrentUser | null) {
+const KEY = "app.currentUser";
+const ACCESS_TOKEN_COOKIE = "PRISM-ACCESS-TOKEN";
+
+function readCookie(name: string): string | null {
+  if (typeof document === "undefined") return null;
+
+  const cookieString = document.cookie;
+  if (!cookieString) return null;
+
+  const cookies = cookieString.split(";");
+  for (const cookie of cookies) {
+    const [rawName, ...rest] = cookie.split("=");
+    if (!rawName) continue;
+    if (rawName.trim() !== name) continue;
+    return decodeURIComponent(rest.join("=").trim());
+  }
+
+  return null;
+}
+
+export function setCurrentUser(u: StoredCurrentUser | null) {
   if (!u) {
     localStorage.removeItem(KEY);
     return;
@@ -20,7 +42,11 @@ export function getCurrentUser(): CurrentUser | null {
   const s = localStorage.getItem(KEY);
   if (!s) return null;
   try {
-    return JSON.parse(s) as CurrentUser;
+    const stored = JSON.parse(s) as StoredCurrentUser;
+    return {
+      ...stored,
+      accessToken: readCookie(ACCESS_TOKEN_COOKIE),
+    };
   } catch {
     return null;
   }


### PR DESCRIPTION
## Summary
- add a settings page that renders the current user details from local storage via `getCurrentUser`
- register the new settings route and expose it through the sidebar navigation

## Testing
- npm run lint *(fails: existing lint errors in Note.tsx, NoteCreate.tsx, Signup.tsx, User.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68f100adf4948321abe0cc04113c7eb1