### PR TITLE
Stop double encoding CSRF payloads

### DIFF
--- a/pkg/csrf/csrf.go
+++ b/pkg/csrf/csrf.go
@@ -3,7 +3,6 @@ package csrf
 import (
 	"context"
 	"crypto/subtle"
-	"encoding/base64"
 	"errors"
 	"log"
 	"net"
@@ -119,15 +118,15 @@ func (p *BasicCSRFProtector) Middleware() gin.HandlerFunc {
 // Prism の SecretCookie, AccessCookie に用いられる AES-GCM JWT のフォーマットは以下である。
 //
 // --- SecretCookie ---
-//   base64url(AES-GCM([ base64url(json(JwtHeader)) ] . [ base64url(json(JwtClaims{base64url(secretPayload)})) ]))
+//   base64url(AES-GCM([ base64url(json(JwtHeader)) ] . [ base64url(json(JwtClaims{secretPayload})) ]))
 //
 // --- AccessCookie ---
-//   base64url(AES-GCM([ base64url(json(JwtHeader)) ] . [ base64url(json(JwtClaims{base64url(accessPayload)})) ])) . [ base64url(publicPayload) ]
+//   base64url(AES-GCM([ base64url(json(JwtHeader)) ] . [ base64url(json(JwtClaims{accessPayload})) ])) . [ base64url(publicPayload) ]
 //
 // 仕様の詳細は以下である。
 //   - AES-GCM JWT の JwtHeader, JwtClaims は JSON -> base64url でエンコードされ、"." で結合されたのち全体が AES-GCM で暗号化され、base64url で再エンコードされる。
 //   - AES-GCM JWT は全体が AES-GCM で暗号化される際、AAD を付加してよい。付加した AAD は AES-GCM -> base64url で暗号化された文字列に、"." で結合して付加する。
-//   - secretPayload, accessPayload, publicPayload は Prism によって base64url でエンコードされる。
+//   - secretPayload, accessPayload, publicPayload は Prism によって JWT 化の過程で base64url でエンコードされる。
 //   - SecretCookie の JwtClaims は Usr という拡張フィールドを持ち、secretPayload を保存できる。
 //   - AccessCookie の JwtClaims は Usr という拡張フィールドを持ち、accessPayload を保存できる。
 //   - AccessCookie は publicPayload を AAD として付加できる。すなわち publicPayload は改ざんを検知できる。
@@ -602,18 +601,18 @@ func (p *DoubleSubmitCookieCSRFProtector) newSessionTokenPair() (*decryptedToken
 	return &decryptedToken{header: secretHeader, claims: secretClaims}, &decryptedToken{header: accessHeader, claims: accessClaims}, nil
 }
 
-func needsSessionUpdate(secretToken, accessToken *decryptedToken, encodedSecret, encodedAccess string, encodedPublic []byte) bool {
+func needsSessionUpdate(secretToken, accessToken *decryptedToken, secretPayload, accessPayload string, publicPayload []byte) bool {
 	if secretToken == nil || accessToken == nil {
 		return true
 	}
 
-	if subtle.ConstantTimeCompare([]byte(secretToken.claims.Usr), []byte(encodedSecret)) != 1 {
+	if subtle.ConstantTimeCompare([]byte(secretToken.claims.Usr), []byte(secretPayload)) != 1 {
 		return true
 	}
-	if subtle.ConstantTimeCompare([]byte(accessToken.claims.Usr), []byte(encodedAccess)) != 1 {
+	if subtle.ConstantTimeCompare([]byte(accessToken.claims.Usr), []byte(accessPayload)) != 1 {
 		return true
 	}
-	if subtle.ConstantTimeCompare(accessToken.aad, encodedPublic) != 1 {
+	if subtle.ConstantTimeCompare(accessToken.aad, publicPayload) != 1 {
 		return true
 	}
 	return false
@@ -743,20 +742,9 @@ func (p *DoubleSubmitCookieCSRFProtector) ModifyResponse(orig func(*http.Respons
 		accessPayload := resp.Header.Get(p.AccessHeaderName)
 		publicPayload := resp.Header.Get(p.PublicHeaderName)
 
-		encodePayload := func(payload string) string {
-			if payload == "" {
-				return ""
-			}
-			return base64.RawURLEncoding.EncodeToString([]byte(payload))
-		}
-
-		encodedSecretPayload := encodePayload(secretPayload)
-		encodedAccessPayload := encodePayload(accessPayload)
-		encodedPublicPayload := encodePayload(publicPayload)
-
-		var encodedPublicPayloadBytes []byte
-		if encodedPublicPayload != "" {
-			encodedPublicPayloadBytes = []byte(encodedPublicPayload)
+		var publicPayloadBytes []byte
+		if publicPayload != "" {
+			publicPayloadBytes = []byte(publicPayload)
 		}
 
 		resp.Header.Del(p.SecretHeaderName)
@@ -786,7 +774,7 @@ func (p *DoubleSubmitCookieCSRFProtector) ModifyResponse(orig func(*http.Respons
 			}
 		}
 
-		if !needsSessionUpdate(secretToken, accessToken, encodedSecretPayload, encodedAccessPayload, encodedPublicPayloadBytes) {
+		if !needsSessionUpdate(secretToken, accessToken, secretPayload, accessPayload, publicPayloadBytes) {
 			return nil
 		}
 
@@ -797,9 +785,9 @@ func (p *DoubleSubmitCookieCSRFProtector) ModifyResponse(orig func(*http.Respons
 			}
 		}
 
-		secretToken.claims.Usr = encodedSecretPayload
-		accessToken.claims.Usr = encodedAccessPayload
-		accessToken.aad = encodedPublicPayloadBytes
+		secretToken.claims.Usr = secretPayload
+		accessToken.claims.Usr = accessPayload
+		accessToken.aad = publicPayloadBytes
 
 		// secretTokenStr, accessTokenStr, err := p.encryptSessionTokens(secretToken, accessToken, encodedPublicPayloadBytes)
 		secretTokenStr, accessTokenStr, err := p.encryptSessionTokens(secretToken, accessToken, []byte(publicPayload))

--- a/pkg/csrf/csrf_test.go
+++ b/pkg/csrf/csrf_test.go
@@ -3,7 +3,6 @@ package csrf
 import (
 	"bytes"
 	"context"
-	"encoding/base64"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -191,23 +190,23 @@ func TestModifyResponseEncodesPayloads(t *testing.T) {
 	hdrSecret := &jwt.JwtHeader{Alg: protector.JwtAlg, Cty: protector.JwtCty, Typ: protector.JwtTyp}
 	hdrAccess := &jwt.JwtHeader{Alg: protector.JwtAlg, Cty: protector.JwtCty, Typ: protector.JwtTyp}
 
-	encodedOldSecret := base64.RawURLEncoding.EncodeToString([]byte("secret-old"))
-	encodedOldAccess := base64.RawURLEncoding.EncodeToString([]byte("access-old"))
-	encodedOldPublic := base64.RawURLEncoding.EncodeToString([]byte("public-old"))
+	oldSecret := "secret-old"
+	oldAccess := "access-old"
+	oldPublic := "public-old"
 
 	clSecret := &jwt.JwtClaims{
 		Jti: jti,
 		Iat: now.Unix(),
 		Nbf: now.Unix(),
 		Exp: now.Add(protector.SessionTTL).Unix(),
-		Usr: encodedOldSecret,
+		Usr: oldSecret,
 	}
 	clAccess := &jwt.JwtClaims{
 		Jti: jti,
 		Iat: now.Unix(),
 		Nbf: now.Unix(),
 		Exp: now.Add(protector.RefreshTTL).Unix(),
-		Usr: encodedOldAccess,
+		Usr: oldAccess,
 	}
 
 	info := &renewedInfo{
@@ -215,7 +214,7 @@ func TestModifyResponseEncodesPayloads(t *testing.T) {
 		hdrAccess:     hdrAccess,
 		clSecret:      clSecret,
 		clAccess:      clAccess,
-		publicPayload: []byte(encodedOldPublic),
+		publicPayload: []byte(oldPublic),
 	}
 
 	req := httptest.NewRequest(http.MethodGet, "https://example.com", nil)
@@ -272,10 +271,6 @@ func TestModifyResponseEncodesPayloads(t *testing.T) {
 		t.Fatal("access cookie not issued")
 	}
 
-	encodedSecret := base64.RawURLEncoding.EncodeToString([]byte(secretPayload))
-	encodedAccess := base64.RawURLEncoding.EncodeToString([]byte(accessPayload))
-	encodedPublic := base64.RawURLEncoding.EncodeToString([]byte(publicPayload))
-
 	hdrSecretJSON, clSecretJSON, _, err := jwt.DecryptWithAAD(encrypter, secretCookie.Value)
 	if err != nil {
 		t.Fatalf("failed to decrypt secret cookie: %v", err)
@@ -284,8 +279,8 @@ func TestModifyResponseEncodesPayloads(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to unmarshal secret claims: %v", err)
 	}
-	if newSecretClaims.Usr != encodedSecret {
-		t.Fatalf("unexpected secret payload: got %q want %q", newSecretClaims.Usr, encodedSecret)
+	if newSecretClaims.Usr != secretPayload {
+		t.Fatalf("unexpected secret payload: got %q want %q", newSecretClaims.Usr, secretPayload)
 	}
 
 	hdrAccessJSON, clAccessJSON, publicAAD, err := jwt.DecryptWithAAD(encrypter, accessCookie.Value)
@@ -296,10 +291,10 @@ func TestModifyResponseEncodesPayloads(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to unmarshal access claims: %v", err)
 	}
-	if newAccessClaims.Usr != encodedAccess {
-		t.Fatalf("unexpected access payload: got %q want %q", newAccessClaims.Usr, encodedAccess)
+	if newAccessClaims.Usr != accessPayload {
+		t.Fatalf("unexpected access payload: got %q want %q", newAccessClaims.Usr, accessPayload)
 	}
-	if string(publicAAD) != encodedPublic {
-		t.Fatalf("unexpected public payload: got %q want %q", string(publicAAD), encodedPublic)
+	if string(publicAAD) != publicPayload {
+		t.Fatalf("unexpected public payload: got %q want %q", string(publicAAD), publicPayload)
 	}
 }


### PR DESCRIPTION
## Summary
- avoid base64url encoding CSRF payloads before encrypting cookies so they are encoded only once
- update the ModifyResponse session refresh logic and expectations to use raw payload values
- adjust ModifyResponse test fixtures to assert on unencoded payloads

## Testing
- not run (go test ./pkg/csrf hung waiting for module downloads)


------
https://chatgpt.com/codex/tasks/task_e_68f43b0f30a08321a06660c578c06b94